### PR TITLE
Change the const-ness of the 1st argument (pointer to the source string)

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,0 @@
-
-utf8.c          gbk ot utf8, utf8 to gbk implement.
-utf8.h          gbk utf8 header file
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+### utf8.c
+GBK to UTF-8 and UTF-8 to GBK conversion implementation.
+
+### utf8.h
+GBK and UTF-8 conversion header file.

--- a/utf8.h
+++ b/utf8.h
@@ -33,7 +33,7 @@ extern "C" {
  * @param len [in] The most bytes which starting at dst, will be written.
  *
  */
-void utf8_to_gb(char* src, char* dst, int len);
+void utf8_to_gb(const char* src, char* dst, int len);
 
 /**
  * GBK to UTF-8
@@ -42,7 +42,7 @@ void utf8_to_gb(char* src, char* dst, int len);
  * @param dst [out]
  * @param len [in] The most bytes which starting at dst, will be written.
  */
-void gb_to_utf8(char* src, char* dst, int len);
+void gb_to_utf8(const char* src, char* dst, int len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Change the 1st argument of both conversion functions from char * to const char *.

This will allow users to pass in const pointers, such as 
```
std::string s;
length = 2 * (s.size() + 1);
char *tmp = new char[length];
gb_to_utf8(s.c_str(), tmp, length);
std::string s_utf8(tmp); // This string is encoded in UTF-8
delete[] tmp;
```

Minor changes:
Rewrite README in Markdown, making it look slightly better.